### PR TITLE
Unset Image Loader References

### DIFF
--- a/src/image-loader.js
+++ b/src/image-loader.js
@@ -82,6 +82,20 @@ Ember.ImageLoader = Ember.Mixin.create( Ember.Evented, {
   },
   
   /**
+    Unsets Reference to the Image Loader.
+    Calling App.reset() or similar will cause a "set on destroyed object"
+    error unless this reference is unset.
+
+    @method unsetImageLoad
+  */
+  unsetImageLoader: function() {
+    img = this.get('imageLoader');
+    img.onload = null;
+    img.onerror = null;
+    this.set('imageLoader', null);
+  }.on('willDestroyElement'),
+  
+  /**
     @private
     Internal onload event handler
     @method _onImgLoad


### PR DESCRIPTION
I'm using some of these libs with https://github.com/rwjblue/ember-qunit, and resetting the App between tests while these elements are on the page causes this uncaught error:

```
Assertion Failed: calling set on destroyed object
```

Unsetting the reference to the image loader & its bound events means app#reset works a lot nicer

:)
